### PR TITLE
Change project name to “IOTA Verifiable Claims Proof of Concept”

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Digitale Waardepapieren
+# IOTA Verifiable Claims Proof of Concept
 
-Status: Proof of Concept
+Status: 👩‍🔬 Proof of Concept
 
 This project is an example of how to use the [IOTA](iota.org) [tangle](https://learn.iota.org/faq/tangle) with [Discipl](https://discipl.org/) library to publish digital [verifiable claims](https://www.w3.org/TR/verifiable-claims-use-cases/). These digital certificates replace the certificates the City of Haarlem has to print on expensive forge-proof paper. Thus increasing the speed and decreasing the cost of our digital service delivery.
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 <img src="ClaimPage/src/assets/logo.png" align="right">
 
-# Digitale Waardepapieren
+# IOTA Verifiable Claims Proof of Concept
 
-Status: Proof of Concept
+Status: 👩‍🔬 Proof of Concept
 
 This project is an example of how to use the [IOTA](iota.org) [tangle](https://learn.iota.org/faq/tangle) with [Discipl](https://discipl.org/) library to publish digital [verifiable claims](https://www.w3.org/TR/verifiable-claims-use-cases/). These digital certificates replace the certificates the City of Haarlem has to print on expensive forge-proof paper. Thus increasing the speed and decreasing the cost of our digital service delivery.
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Digitale Waardepapieren
 
+Status: Proof of Concept
+
 This project is an example of how to use the [IOTA](iota.org) [tangle](https://learn.iota.org/faq/tangle) with [Discipl](https://discipl.org/) library to publish digital [verifiable claims](https://www.w3.org/TR/verifiable-claims-use-cases/). These digital certificates replace the certificates the City of Haarlem has to print on expensive forge-proof paper. Thus increasing the speed and decreasing the cost of our digital service delivery.
 
 * [Why we've made this this Proof of Concept.](docs/proof-of-concept.md)

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 # Digitale Waardepapieren
 
+Status: Proof of Concept
+
 This project is an example of how to use the [IOTA](iota.org) [tangle](https://learn.iota.org/faq/tangle) with [Discipl](https://discipl.org/) library to publish digital [verifiable claims](https://www.w3.org/TR/verifiable-claims-use-cases/). These digital certificates replace the certificates the City of Haarlem has to print on expensive forge-proof paper. Thus increasing the speed and decreasing the cost of our digital service delivery.
 
 * [Why we've made this this Proof of Concept](docs/proof-of-concept.md)


### PR DESCRIPTION
Fixes #14 and replaces #23

## Why get rid of “Digitale Waardepapieren”?

This Dutch name doesn’t really mean that much outside of the context of the Gemeente Haarlem.

## Why “IOTA Verifiable Claims Proof of Concept”?

* IOTA: This is the technology used and thus will indicate to those that are already interested in the IOTA tangle that this project is for them
* Verifiable Claims: What we’re actually trying to achieve with this repository is that we can show there is a usecase for ‘Blockchain’ in public administrations.
* Proof of Concept: This is not a production ready application and mostly a show and tell of how it works.

## To do after this

Preferably we change the name of the repo to `iota-verifiable-claims` to reflect the project name change.